### PR TITLE
Made "name" the name_attribute of the resource

### DIFF
--- a/resources/record.rb
+++ b/resources/record.rb
@@ -2,7 +2,7 @@ actions :create, :delete
 
 default_action :create
 
-attribute :name,                  :kind_of => String, :required => true
+attribute :name,                  :kind_of => String, :required => true, :name_attribute => true
 attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600


### PR DESCRIPTION
This will allow you to use the resource name as the dns name.  This is a backwards compatible change.