### PR TITLE
depends xml to to support installing fog

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -5,4 +5,4 @@ site 'https://supermarket.getchef.com/api/v1'
 cookbook 'route53', path: '.'
 cookbook 'route53_test', path: './test/integration/cookbooks/route53_test'
 
-cookbook 'build-essential'
+cookbook 'xml'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,1 @@
-default['build_essential']['compiletime'] = true
-default['build-essential']['compile_time'] = true
-default['route53']['nokogiri_version'] = '1.6.3.1'
-default['route53']['fog_version'] = '1.24'
+default['route53']['fog_version'] = '1.27'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "support@hw-ops.com"
 license          "Apache 2.0"
 description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.9"
+version          "0.4.0"
 
-depends 'build-essential'
+depends 'xml'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,34 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'build-essential'
-
-if node['platform_family'] == 'debian'
-   xml = package "libxml2-dev" do
-      action :nothing
-   end
-   xml.run_action( :install )
-
-   xslt = package "libxslt1-dev" do
-      action :nothing
-   end
-   xslt.run_action( :install )
-elsif node['platform_family'] == 'rhel'
-   xml = package "libxml2-devel" do
-      action :nothing
-   end
-   xml.run_action( :install )
-
-   xslt = package "libxslt-devel" do
-      action :nothing
-   end
-   xslt.run_action( :install )
-end
-
-chef_gem 'nokogiri' do
-  action :install
-  version node['route53']['nokogiri_version']
-end
+include_recipe 'xml::ruby'
 
 chef_gem "fog" do
   action :install


### PR DESCRIPTION
Removes installation of build-essentials and all of the supporting libraries (eg. nokogiri). These dependencies are now provided by `include_recipe 'xml::ruby'`