### PR TITLE
use release version of xml

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.4.0"
 
-depends 'xml'
+depends 'xml', '<= 1.2.9'


### PR DESCRIPTION
upstream xml release commits broke our builds after xml 1.2.9 in opsworks. :(