### PR TITLE
Add Geo location support

### DIFF
--- a/providers/record.rb
+++ b/providers/record.rb
@@ -141,6 +141,10 @@ action :create do
       (alias_target['dns_name'] == record.alias_target['DNSName'].gsub(/\.$/,''))
   end
 
+  def same_geo_location_country?(record)
+    geo_location_country.eql?(record.geo_location.values[0])
+  end
+
   if record.nil?
     create
     Chef::Log.info "Record created: #{name}"

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -30,6 +30,10 @@ def geo_location_country
   @geo_location_country ||= new_resource.geo_location_country
 end
 
+def geo_location_continent
+  @geo_location_continent ||= new_resource.geo_location_continent
+end
+
 def geo_location
   @geo_location ||= new_resource.geo_location
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -141,10 +141,6 @@ action :create do
       (alias_target['dns_name'] == record.alias_target['DNSName'].gsub(/\.$/,''))
   end
 
-  def same_geo_location_country?(record)
-    geo_location_country.eql?(record.geo_location.values[0])
-  end
-
   def same_set_identifier?(record)
     set_identifier.eql?(record.set_identifier)
   end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -69,7 +69,7 @@ end
 
 def record_attributes
   common_attributes = { :name => name, :type => type }
-  common_attributes.merge(record_value_or_alias_attributes)
+  common_attributes.merge(record_value_or_geo_location_or_alias_attributes)
 end
 
 def record
@@ -78,9 +78,11 @@ def record
   records.count.zero? ? nil : records.get(name, type, set_identifier)
 end
 
-def record_value_or_alias_attributes
+def record_value_or_geo_location_or_alias_attributes
   if alias_target
     { :alias_target => alias_target.to_hash }
+  elsif geo_location
+    { :value => value, :ttl => ttl, :set_identifier => set_identifier, :geo_location => geo_location }
   else
     { :value => value, :ttl => ttl }
   end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -178,8 +178,8 @@ action :delete do
   end
 
   def delete
-    zone(aws).records.get(name, type).destroy
-    Chef::Log.debug("Destroyed record: #{name} #{type}")
+    zone(aws).records.get(name, type, set_identifier).destroy
+    Chef::Log.debug("Destroyed record: #{name} #{type} #{set_identifier}")
   rescue Excon::Errors::BadRequest => e
     Chef::Log.error Nokogiri::XML(e.response.body).xpath('//xmlns:Message').text
   end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -39,7 +39,15 @@ def geo_location_subdivision
 end
 
 def geo_location
-  @geo_location ||= new_resource.geo_location
+  if geo_location_country
+    "<CountryCode>#{geo_location_country}</CountryCode>"
+  elsif geo_location_continent
+    "<ContinentCode>#{geo_location_continent}</ContinentCode>"
+  elsif geo_location_subdivision
+    "<CountryCode>#{geo_location_country}</CountryCode>"&"<SubdivisionCode>#{geo_location_subdivision}</SubdivisionCode>"
+  else
+    @geo_location ||= new_resource.geo_location
+  end
 end
 
 def set_identifier

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -40,11 +40,11 @@ end
 
 def geo_location
   if geo_location_country
-    "<CountryCode>#{geo_location_country}</CountryCode>"
+    { "CountryCode" => geo_location_country }
   elsif geo_location_continent
-    "<ContinentCode>#{geo_location_continent}</ContinentCode>"
+    { "ContinentCode" => geo_location_continent }
   elsif geo_location_subdivision
-    "<CountryCode>#{geo_location_country}</CountryCode>"&"<SubdivisionCode>#{geo_location_subdivision}</SubdivisionCode>"
+    { "CountryCode" => geo_location_country, "SubdivisionCode" => geo_location_subdivision }
   else
     @geo_location ||= new_resource.geo_location
   end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -26,6 +26,10 @@ def ttl
   @ttl ||= new_resource.ttl
 end
 
+def geo_location
+  @geo_location ||= new_resource.geo_location
+end
+
 def overwrite
   @overwrite ||= new_resource.overwrite
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -124,7 +124,8 @@ action :create do
   def same_record?(record)
     name.eql?(record.name) &&
       same_value?(record) &&
-        ttl.eql?(record.ttl.to_i)
+        ttl.eql?(record.ttl.to_i) &&
+          same_set_identifier?(record)
   end
 
   def same_value?(record)

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -145,6 +145,10 @@ action :create do
     geo_location_country.eql?(record.geo_location.values[0])
   end
 
+  def same_set_identifier?(record)
+    set_identifier.eql?(record.set_identifier)
+  end
+
   if record.nil?
     create
     Chef::Log.info "Record created: #{name}"

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -34,6 +34,10 @@ def geo_location_continent
   @geo_location_continent ||= new_resource.geo_location_continent
 end
 
+def geo_location_subdivision
+  @geo_location_subdivision ||= new_resource.geo_location_subdivision
+end
+
 def geo_location
   @geo_location ||= new_resource.geo_location
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -30,6 +30,10 @@ def geo_location
   @geo_location ||= new_resource.geo_location
 end
 
+def set_identifier
+  @set_identifier ||= new_resource.set_identifier
+end
+
 def overwrite
   @overwrite ||= new_resource.overwrite
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -26,6 +26,10 @@ def ttl
   @ttl ||= new_resource.ttl
 end
 
+def geo_location_country
+  @geo_location_country ||= new_resource.geo_location_country
+end
+
 def geo_location
   @geo_location ||= new_resource.geo_location
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -73,9 +73,9 @@ def record_attributes
 end
 
 def record
-  Chef::Log.info("Getting record: #{name} #{type}")
+  Chef::Log.info("Getting record: #{name} #{type} #{set_identifier}")
   records = zone(aws).records
-  records.count.zero? ? nil : records.get(name, type)
+  records.count.zero? ? nil : records.get(name, type, set_identifier)
 end
 
 def record_value_or_alias_attributes

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -7,6 +7,7 @@ attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :geo_location,          :kind_of => String, :default => "*"
+attribute :set_identifier,        :kind_of => String
 attribute :zone_id,               :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String
 attribute :aws_secret_access_key, :kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -6,7 +6,7 @@ attribute :name,                  :kind_of => String, :required => true, :name_a
 attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
-attribute :geo_location,          :kind_of => String, :default => "*"
+attribute :geo_location,          :kind_of => String, :default => "<CountryCode>*</CountryCode>"
 attribute :geo_location_country,  :kind_of => String, :default => "*"
 attribute :geo_location_continent,:kind_of => String
 attribute :geo_location_subdivision,:kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -8,6 +8,7 @@ attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :geo_location,          :kind_of => String, :default => "*"
 attribute :geo_location_country,  :kind_of => String, :default => "*"
+attribute :geo_location_continent,:kind_of => String
 attribute :set_identifier,        :kind_of => String
 attribute :zone_id,               :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -6,6 +6,7 @@ attribute :name,                  :kind_of => String, :required => true, :name_a
 attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
+attribute :geo_location,          :kind_of => String, :default => "*"
 attribute :zone_id,               :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String
 attribute :aws_secret_access_key, :kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -6,8 +6,8 @@ attribute :name,                        :kind_of => String, :required => true, :
 attribute :value,                       :kind_of => [ String, Array ]
 attribute :type,                        :kind_of => String, :required => true
 attribute :ttl,                         :kind_of => Integer, :default => 3600
-attribute :geo_location,                :kind_of => String, :default => "<CountryCode>*</CountryCode>"
-attribute :geo_location_country,        :kind_of => String, :default => "*"
+attribute :geo_location,                :kind_of => String
+attribute :geo_location_country,        :kind_of => String
 attribute :geo_location_continent,      :kind_of => String
 attribute :geo_location_subdivision,    :kind_of => String
 attribute :set_identifier,              :kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -7,6 +7,7 @@ attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :geo_location,          :kind_of => String, :default => "*"
+attribute :geo_location_country,  :kind_of => String, :default => "*"
 attribute :set_identifier,        :kind_of => String
 attribute :zone_id,               :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -9,6 +9,7 @@ attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :geo_location,          :kind_of => String, :default => "*"
 attribute :geo_location_country,  :kind_of => String, :default => "*"
 attribute :geo_location_continent,:kind_of => String
+attribute :geo_location_subdivision,:kind_of => String
 attribute :set_identifier,        :kind_of => String
 attribute :zone_id,               :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -2,19 +2,19 @@ actions :create, :delete
 
 default_action :create
 
-attribute :name,                  :kind_of => String, :required => true, :name_attribute => true
-attribute :value,                 :kind_of => [ String, Array ]
-attribute :type,                  :kind_of => String, :required => true
-attribute :ttl,                   :kind_of => Integer, :default => 3600
-attribute :geo_location,          :kind_of => String, :default => "<CountryCode>*</CountryCode>"
-attribute :geo_location_country,  :kind_of => String, :default => "*"
-attribute :geo_location_continent,:kind_of => String
-attribute :geo_location_subdivision,:kind_of => String
-attribute :set_identifier,        :kind_of => String
-attribute :zone_id,               :kind_of => String
-attribute :aws_access_key_id,     :kind_of => String
-attribute :aws_secret_access_key, :kind_of => String
-attribute :aws_session_token,     :kind_of => String
-attribute :overwrite,             :kind_of => [ TrueClass, FalseClass ], :default => true
-attribute :alias_target,          :kind_of => Hash
-attribute :mock,                  kind_of: [TrueClass, FalseClass], default: false
+attribute :name,                        :kind_of => String, :required => true, :name_attribute => true
+attribute :value,                       :kind_of => [ String, Array ]
+attribute :type,                        :kind_of => String, :required => true
+attribute :ttl,                         :kind_of => Integer, :default => 3600
+attribute :geo_location,                :kind_of => String, :default => "<CountryCode>*</CountryCode>"
+attribute :geo_location_country,        :kind_of => String, :default => "*"
+attribute :geo_location_continent,      :kind_of => String
+attribute :geo_location_subdivision,    :kind_of => String
+attribute :set_identifier,              :kind_of => String
+attribute :zone_id,                     :kind_of => String
+attribute :aws_access_key_id,           :kind_of => String
+attribute :aws_secret_access_key,       :kind_of => String
+attribute :aws_session_token,           :kind_of => String
+attribute :overwrite,                   :kind_of => [ TrueClass, FalseClass ], :default => true
+attribute :alias_target,                :kind_of => Hash
+attribute :mock,                        kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
Route53 support geo_location records, and fog-aws support that too, only this cookbook doesn't.

I made the changes that support geo_location records.

Please let me know if you'd like to add some changes.