### PR TITLE
Gem compile time

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@ include_recipe 'xml::ruby'
 
 chef_gem "fog" do
   action :install
+  compile_time false
   version node['route53']['fog_version']
 end
 


### PR DESCRIPTION
Set compile_time false for install of fog chef_gem, to remove the deprecation warning.