### PR TITLE
fog version 1.37.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,1 @@
-default['route53']['fog_version'] = '1.27'
+default['route53']['fog_version'] = '1.37.0'


### PR DESCRIPTION
This will be included in what will likely be the last minor version release of the cookbook to use `fog` before a major release moving to using the `aws-sdk` so I'll bump to the latest released version for default.